### PR TITLE
feat: 진단 검사 결과 저장 API 호출 시 보호자 SMS 알림 서비스

### DIFF
--- a/src/main/java/com/ssafy/soljigi/diagnosis/controller/DiagnosisController.java
+++ b/src/main/java/com/ssafy/soljigi/diagnosis/controller/DiagnosisController.java
@@ -57,7 +57,7 @@ public class DiagnosisController {
 	public ApiResponse<?> saveResult(@RequestBody DiagnosisResultSaveRequest saveRequest) {
 		log.info("saveRequest={}", saveRequest);
 		resultService.save(saveRequest);
-		// 보호자에게 SMS 문자 전송 기능 추가
+		// 보호자에게 sms 문자 전송 기능 추가
 		return ApiResponse.ofSuccess();
 	}
 

--- a/src/main/java/com/ssafy/soljigi/diagnosis/controller/DiagnosisController.java
+++ b/src/main/java/com/ssafy/soljigi/diagnosis/controller/DiagnosisController.java
@@ -1,5 +1,9 @@
 package com.ssafy.soljigi.diagnosis.controller;
 
+import java.net.URISyntaxException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -12,7 +16,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.client.RestClientException;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.ssafy.soljigi.base.api.response.ApiResponse;
 import com.ssafy.soljigi.diagnosis.dto.request.DiagnosisResultSaveRequest;
 import com.ssafy.soljigi.diagnosis.dto.response.DiagnosisResultResponse;
@@ -21,6 +27,8 @@ import com.ssafy.soljigi.diagnosis.service.DiagnosisResultService;
 import com.ssafy.soljigi.diagnosis.service.ExecutiveService;
 import com.ssafy.soljigi.diagnosis.service.MemoryService;
 import com.ssafy.soljigi.diagnosis.service.OrientService;
+import com.ssafy.soljigi.sms.dto.SmsResponseDTO;
+import com.ssafy.soljigi.sms.service.SmsService;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -38,6 +46,7 @@ public class DiagnosisController {
 	private final ExecutiveService executiveService;
 	// private final LanguageService languageService;
 	private final DiagnosisResultService resultService;
+	private final SmsService smsService;
 
 	@GetMapping
 	public String diagnosis(Model model) {
@@ -56,9 +65,19 @@ public class DiagnosisController {
 	@PostMapping
 	public ApiResponse<?> saveResult(@RequestBody DiagnosisResultSaveRequest saveRequest) {
 		log.info("saveRequest={}", saveRequest);
-		resultService.save(saveRequest);
+		Map<String, Object> data = new HashMap<>();
+		try {
+			Long savedId = resultService.save(saveRequest);
+			data.put("id", savedId);
+
+			SmsResponseDTO response = smsService.sendDiagnosticResult(saveRequest.getUserId(),
+				saveRequest.getDiagnosticResult());
+			data.put("smsSend", response);
+		} catch (IllegalArgumentException e) {
+			ApiResponse.ofError("존재하지 않는 회원입니다.");
+		}
 		// 보호자에게 sms 문자 전송 기능 추가
-		return ApiResponse.ofSuccess();
+		return ApiResponse.ofSuccess(data);
 	}
 
 	@ResponseBody
@@ -67,4 +86,5 @@ public class DiagnosisController {
 		List<DiagnosisResultResponse> data = resultService.findAll(userId);
 		return ApiResponse.ofSuccess(data);
 	}
+
 }

--- a/src/main/java/com/ssafy/soljigi/diagnosis/dto/request/DiagnosisResultSaveRequest.java
+++ b/src/main/java/com/ssafy/soljigi/diagnosis/dto/request/DiagnosisResultSaveRequest.java
@@ -20,4 +20,23 @@ public class DiagnosisResultSaveRequest {
 	private int executiveScore;        // 집행기능
 	private int languageScore;        // 언어
 	private int memoryScore;        // 기억력
+
+	public String getDiagnosticResult() {
+		return "진단 검사 결과가 다음과 같습니다.\n"
+			+ "이름 : 추가예정\n"
+			+ "나이 : " + age + "\n"
+			+ "지남력 : " + orientScore + "/5\n"
+			+ "주의력 : " + attentionScore + "/3\n"
+			+ "시공간기능 : " + spacetimeScore + "/2\n"
+			+ "집행기능 : " + executiveScore + "/6\n"
+			+ "기억력 : " + memoryScore + "/10\n"
+			+ "언어기능 : " + languageScore + "/4\n"
+			+ "총점 : " + getTotalScore() + "\n"
+			+ "검사 진행 결과 : " + "정상";
+	}
+
+	public int getTotalScore() {
+		return orientScore + attentionScore + spacetimeScore
+				+ executiveScore + languageScore + memoryScore;
+	}
 }

--- a/src/main/java/com/ssafy/soljigi/diagnosis/service/LanguageService.java
+++ b/src/main/java/com/ssafy/soljigi/diagnosis/service/LanguageService.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
 
-// @Service
+// @service
 @RequiredArgsConstructor
 public class LanguageService {
 

--- a/src/main/java/com/ssafy/soljigi/sms/controller/SmsController.java
+++ b/src/main/java/com/ssafy/soljigi/sms/controller/SmsController.java
@@ -1,4 +1,4 @@
-package com.ssafy.soljigi.SMS.Controller;
+package com.ssafy.soljigi.sms.controller;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URISyntaxException;
@@ -12,9 +12,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.client.RestClientException;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.ssafy.soljigi.SMS.DTO.MessageDTO;
-import com.ssafy.soljigi.SMS.DTO.SmsResponseDTO;
-import com.ssafy.soljigi.SMS.Service.SmsService;
+import com.ssafy.soljigi.sms.dto.MessageDTO;
+import com.ssafy.soljigi.sms.service.SmsService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -35,7 +34,7 @@ public class SmsController {
 		RestClientException,
 		URISyntaxException, InvalidKeyException, NoSuchAlgorithmException, UnsupportedEncodingException {
 		// messageDto.setTo("01088373012");
-		// messageDto.setContent("신한은행 해커톤 SMS 테스트");
+		// messageDto.setContent("신한은행 해커톤 sms 테스트");
 		// SmsResponseDTO response = smsService.sendSms(messageDto);
 		// model.addAttribute("response", response);
 		return "SMS/result";

--- a/src/main/java/com/ssafy/soljigi/sms/dto/MessageDTO.java
+++ b/src/main/java/com/ssafy/soljigi/sms/dto/MessageDTO.java
@@ -1,10 +1,9 @@
-package com.ssafy.soljigi.SMS.DTO;
+package com.ssafy.soljigi.sms.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @AllArgsConstructor
 @NoArgsConstructor

--- a/src/main/java/com/ssafy/soljigi/sms/dto/SmsRequestDTO.java
+++ b/src/main/java/com/ssafy/soljigi/sms/dto/SmsRequestDTO.java
@@ -1,4 +1,4 @@
-package com.ssafy.soljigi.SMS.DTO;
+package com.ssafy.soljigi.sms.dto;
 
 import java.util.List;
 

--- a/src/main/java/com/ssafy/soljigi/sms/dto/SmsResponseDTO.java
+++ b/src/main/java/com/ssafy/soljigi/sms/dto/SmsResponseDTO.java
@@ -1,7 +1,6 @@
-package com.ssafy.soljigi.SMS.DTO;
+package com.ssafy.soljigi.sms.dto;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/ssafy/soljigi/sms/service/SmsService.java
+++ b/src/main/java/com/ssafy/soljigi/sms/service/SmsService.java
@@ -3,6 +3,7 @@ package com.ssafy.soljigi.sms.service;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
@@ -23,9 +24,12 @@ import org.springframework.web.client.RestTemplate;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ssafy.soljigi.diagnosis.dto.request.DiagnosisResultSaveRequest;
 import com.ssafy.soljigi.sms.dto.MessageDTO;
 import com.ssafy.soljigi.sms.dto.SmsRequestDTO;
 import com.ssafy.soljigi.sms.dto.SmsResponseDTO;
+import com.ssafy.soljigi.user.entity.User;
+import com.ssafy.soljigi.user.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -46,39 +50,30 @@ public class SmsService {
 	@Value("${naver-cloud-sms.senderPhone}")
 	private String phone;
 
-	public String makeSignature(Long time) throws NoSuchAlgorithmException, UnsupportedEncodingException, InvalidKeyException {
-		String space = " ";
-		String newLine = "\n";
-		String method = "POST";
-		String url = "/sms/v2/services/"+ this.serviceId+"/messages";
-		String timestamp = time.toString();
-		String accessKey = this.accessKey;
-		String secretKey = this.secretKey;
+	private final UserRepository userRepository;
 
-		String message = new StringBuilder()
-			.append(method)
-			.append(space)
-			.append(url)
-			.append(newLine)
-			.append(timestamp)
-			.append(newLine)
-			.append(accessKey)
-			.toString();
+	public SmsResponseDTO sendDiagnosticResult(Long userId, String content) {
+		User user = userRepository.findById(userId)
+			.orElseThrow(IllegalArgumentException::new);
 
-		SecretKeySpec signingKey = new SecretKeySpec(secretKey.getBytes("UTF-8"), "HmacSHA256");
-		Mac mac = Mac.getInstance("HmacSHA256");
-		mac.init(signingKey);
-
-		byte[] rawHmac = mac.doFinal(message.getBytes("UTF-8"));
-		String encodeBase64String = Base64.encodeBase64String(rawHmac);
-
-		return encodeBase64String;
+		// String phoneNumber = user.getCareGiverNumber();
+		String phoneNumber = "01089258114";
+		SmsResponseDTO response;
+		try {
+			response = sendSms(new MessageDTO(phoneNumber, content));
+ 		} catch (UnsupportedEncodingException | URISyntaxException | NoSuchAlgorithmException | InvalidKeyException |
+				 JsonProcessingException e) {
+			// throw new RuntimeException(e);
+			return null;
+		}
+		return response;
 	}
 
 	public SmsResponseDTO sendSms(MessageDTO messageDto) throws
 		JsonProcessingException,
 		RestClientException,
 		URISyntaxException, InvalidKeyException, NoSuchAlgorithmException, UnsupportedEncodingException {
+
 		Long time = System.currentTimeMillis();
 
 		HttpHeaders headers = new HttpHeaders();
@@ -108,5 +103,30 @@ public class SmsService {
 		SmsResponseDTO response = restTemplate.postForObject(new URI("https://sens.apigw.ntruss.com/sms/v2/services/"+ serviceId +"/messages"), httpBody, SmsResponseDTO.class);
 
 		return response;
+	}
+
+	private String makeSignature(Long time) throws NoSuchAlgorithmException, UnsupportedEncodingException, InvalidKeyException {
+		String space = " ";
+		String newLine = "\n";
+		String method = "POST";
+		String url = "/sms/v2/services/"+ this.serviceId+"/messages";
+		String timestamp = time.toString();
+		String accessKey = this.accessKey;
+		String secretKey = this.secretKey;
+
+		String message = method
+			+ space
+			+ url
+			+ newLine
+			+ timestamp
+			+ newLine
+			+ accessKey;
+
+		SecretKeySpec signingKey = new SecretKeySpec(secretKey.getBytes("UTF-8"), "HmacSHA256");
+		Mac mac = Mac.getInstance("HmacSHA256");
+		mac.init(signingKey);
+
+		byte[] rawHmac = mac.doFinal(message.getBytes(StandardCharsets.UTF_8));
+		return Base64.encodeBase64String(rawHmac);
 	}
 }

--- a/src/main/java/com/ssafy/soljigi/sms/service/SmsService.java
+++ b/src/main/java/com/ssafy/soljigi/sms/service/SmsService.java
@@ -1,4 +1,4 @@
-package com.ssafy.soljigi.SMS.Service;
+package com.ssafy.soljigi.sms.service;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
@@ -23,9 +23,9 @@ import org.springframework.web.client.RestTemplate;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.ssafy.soljigi.SMS.DTO.MessageDTO;
-import com.ssafy.soljigi.SMS.DTO.SmsRequestDTO;
-import com.ssafy.soljigi.SMS.DTO.SmsResponseDTO;
+import com.ssafy.soljigi.sms.dto.MessageDTO;
+import com.ssafy.soljigi.sms.dto.SmsRequestDTO;
+import com.ssafy.soljigi.sms.dto.SmsResponseDTO;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -91,7 +91,7 @@ public class SmsService {
 		messages.add(messageDto);
 
 		SmsRequestDTO request = SmsRequestDTO.builder()
-			.type("SMS")
+			.type("sms")
 			.contentType("COMM")
 			.countryCode("82")
 			.from(phone)


### PR DESCRIPTION
## :white_check_mark:DONE
- 진단 검사 결과 저장 API 호출 시 SMS Service 호출
- DiagnosisResultSaveRequest 엔티티 수정
    - getDiagnosticResult 메서드 추가

## :white_check_mark:TODO
- SMS 문자의 내용이 잘리는 문제있음

## :white_check_mark:RESULT
### API 호출
![image](https://github.com/SSAFYxShinhan/SolJiGi/assets/80024307/418546e9-f2c9-4a3c-ac37-10fa7f915bda)

### 문자 
![image](https://github.com/SSAFYxShinhan/SolJiGi/assets/80024307/97f19859-1871-4bc5-97a9-b4ac8edb3a99)

