### PR TITLE
feat: 게임 클리어 시 유저의 포인트 증가, 게임 결과 반환 시 진행 날짜 포함

### DIFF
--- a/src/main/java/com/ssafy/soljigi/SoljigiApplication.java
+++ b/src/main/java/com/ssafy/soljigi/SoljigiApplication.java
@@ -2,8 +2,10 @@ package com.ssafy.soljigi;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class SoljigiApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/ssafy/soljigi/base/entity/BaseEntity.java
+++ b/src/main/java/com/ssafy/soljigi/base/entity/BaseEntity.java
@@ -1,0 +1,25 @@
+package com.ssafy.soljigi.base.entity;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+@Getter
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime registrationDate;
+
+    @LastModifiedDate
+    private LocalDateTime lastModifiedDate;
+}

--- a/src/main/java/com/ssafy/soljigi/diagnosis/dto/response/DiagnosisResultResponse.java
+++ b/src/main/java/com/ssafy/soljigi/diagnosis/dto/response/DiagnosisResultResponse.java
@@ -7,6 +7,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Builder
 @AllArgsConstructor
@@ -21,6 +23,7 @@ public class DiagnosisResultResponse {
 	private int languageScore;        // 언어
 	private int memoryScore;        // 기억력
 	private DiagnosisResultType type;
+	private LocalDateTime registrationDate;
 
 	public static DiagnosisResultResponse of(DiagnosisResult diagnosisResult) {
 		return DiagnosisResultResponse.builder()
@@ -33,6 +36,7 @@ public class DiagnosisResultResponse {
 			.languageScore(diagnosisResult.getLanguageScore())
 			.memoryScore(diagnosisResult.getMemoryScore())
 			.type(diagnosisResult.getType())
+			.registrationDate(diagnosisResult.getRegistrationDate())
 			.build();
 	}
 }

--- a/src/main/java/com/ssafy/soljigi/diagnosis/entity/DiagnosisQuiz.java
+++ b/src/main/java/com/ssafy/soljigi/diagnosis/entity/DiagnosisQuiz.java
@@ -2,24 +2,17 @@ package com.ssafy.soljigi.diagnosis.entity;
 
 import java.util.List;
 
+import com.ssafy.soljigi.base.entity.BaseEntity;
+import jakarta.persistence.*;
 import org.hibernate.annotations.BatchSize;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.ElementCollection;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
 
-// @Entity
+@Entity
 @Getter
-@ToString
-public class DiagnosisQuiz {
+public class DiagnosisQuiz extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/ssafy/soljigi/diagnosis/entity/DiagnosisResult.java
+++ b/src/main/java/com/ssafy/soljigi/diagnosis/entity/DiagnosisResult.java
@@ -1,5 +1,6 @@
 package com.ssafy.soljigi.diagnosis.entity;
 
+import com.ssafy.soljigi.base.entity.BaseEntity;
 import com.ssafy.soljigi.user.entity.User;
 
 import jakarta.persistence.Entity;
@@ -22,7 +23,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class DiagnosisResult {
+public class DiagnosisResult extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/ssafy/soljigi/game/controller/GameApiController.java
+++ b/src/main/java/com/ssafy/soljigi/game/controller/GameApiController.java
@@ -37,7 +37,7 @@ public class GameApiController {
 		return ApiResponse.ofSuccess(savedId);
 	}
 
-	@GetMapping("result/{userId}")
+	@GetMapping("/result/{userId}")
 	public ApiResponse<?> searchResult(@PathVariable("userId") Long userId) {
 		List<GameResultResponse> data = resultService.findAll(userId);
 		return ApiResponse.ofSuccess(data);

--- a/src/main/java/com/ssafy/soljigi/game/dto/GameResultResponse.java
+++ b/src/main/java/com/ssafy/soljigi/game/dto/GameResultResponse.java
@@ -7,6 +7,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Builder
 @AllArgsConstructor
@@ -22,6 +24,7 @@ public class GameResultResponse {
 	private int samePictureTotal;
 	private int correctCount;
 	private int totalCount;
+	private LocalDateTime registrationDate;
 
 	public static GameResultResponse of(GameResult gameResult) {
 		return GameResultResponse.builder()
@@ -35,6 +38,7 @@ public class GameResultResponse {
 			.samePictureTotal(gameResult.getSamePictureTotal())
 			.correctCount(gameResult.getCorrectCount())
 			.totalCount(gameResult.getTotalCount())
+			.registrationDate(gameResult.getRegistrationDate())
 			.build();
 	}
 }

--- a/src/main/java/com/ssafy/soljigi/game/entity/GameResult.java
+++ b/src/main/java/com/ssafy/soljigi/game/entity/GameResult.java
@@ -1,5 +1,6 @@
 package com.ssafy.soljigi.game.entity;
 
+import com.ssafy.soljigi.base.entity.BaseEntity;
 import com.ssafy.soljigi.user.entity.User;
 
 import jakarta.persistence.Entity;
@@ -20,7 +21,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class GameResult {
+public class GameResult extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/ssafy/soljigi/game/entity/Quiz.java
+++ b/src/main/java/com/ssafy/soljigi/game/entity/Quiz.java
@@ -2,6 +2,7 @@ package com.ssafy.soljigi.game.entity;
 
 import java.util.List;
 
+import com.ssafy.soljigi.base.entity.BaseEntity;
 import org.hibernate.annotations.BatchSize;
 
 import jakarta.persistence.Column;
@@ -18,7 +19,7 @@ import lombok.Getter;
 
 @Entity
 @Getter
-public class Quiz {
+public class Quiz extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/ssafy/soljigi/game/service/GameResultService.java
+++ b/src/main/java/com/ssafy/soljigi/game/service/GameResultService.java
@@ -30,8 +30,9 @@ public class GameResultService {
 	public Long save(GameResultSaveRequest saveRequest) {
 		User user = userRepository.findById(saveRequest.getUserId())
 			.orElseThrow(IllegalArgumentException::new);
+		
+		user.increasePoint(saveRequest.getCorrectCount());	// 맞춘 문제 수 만큼 포인트 증가
 
-		// age, educationLevel -> userEntity getter로 변경 예정
 		GameResult saved = resultRepository.save(GameResult.builder()
 			.user(user)
 			.choiceCorrect(saveRequest.getChoiceCorrect())

--- a/src/main/java/com/ssafy/soljigi/user/entity/User.java
+++ b/src/main/java/com/ssafy/soljigi/user/entity/User.java
@@ -47,8 +47,14 @@ public class User implements UserDetails {
 	private String phoneNumber;
 	private String accountNumber;
 
+	private int point;
+
 	@Enumerated(EnumType.STRING)
 	private Role role;
+
+	public void increasePoint(int point) {
+		this.point += point;
+	}
 
 	@Override
 	public Collection<? extends GrantedAuthority> getAuthorities() {
@@ -62,7 +68,6 @@ public class User implements UserDetails {
 
 	@Override
 	public String getUsername() {
-		// email in our case
 		return username;
 	}
 

--- a/src/main/java/com/ssafy/soljigi/user/entity/User.java
+++ b/src/main/java/com/ssafy/soljigi/user/entity/User.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.Collection;
 import java.util.List;
 
+import com.ssafy.soljigi.base.entity.BaseEntity;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -27,7 +28,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "_user")
-public class User implements UserDetails {
+public class User extends BaseEntity implements UserDetails {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
## :white_check_mark:DONE
- 게임 클리어 시 점수 만큼 유저의 포인트 증가
- 진단 검사, 게임 결과 내역 반환 시 진행 날짜 포함
- BaseEntity추가
- User, Quiz, DiagnosisQuiz, GameResult, DiagnosisResult에 BaseEntity 적용

## :white_check_mark:TODO
- diagnosis 패키지 리팩토링

## :white_check_mark:RESULT 
### 유저 포인트 증가
correct 개수가 13이므로 user 1의 13포인트 증가
![image](https://github.com/SSAFYxShinhan/SolJiGi/assets/80024307/48ce4dde-813d-4420-9122-3ce54926cb24)
#### User Table
![image](https://github.com/SSAFYxShinhan/SolJiGi/assets/80024307/bcac456f-ca70-4f83-908b-deaa6bfeb141)


### 게임 결과 내역 조회(registrationDate 필드 추가)
![image](https://github.com/SSAFYxShinhan/SolJiGi/assets/80024307/e2929a5b-597c-4e71-b709-4052a4f0e193)
